### PR TITLE
Add config AARCH64 to support ARM64

### DIFF
--- a/ext/cld/base/build_config.h
+++ b/ext/cld/base/build_config.h
@@ -98,7 +98,7 @@
 #elif defined(__ARCH_PPC) || defined(__ppc__)
 #define ARCH_CPU_PPC_FAMILY 1
 #define ARCH_CPU_32_BITS 1
-#elif defined(__arm64)
+#elif defined(__arm64) || defined(__aarch64__)
 #define ARCH_CPU_ARM_FAMILY 1
 #define ARCH_CPU_ARM64 1
 #define ARCH_CPU_64_BITS 1

--- a/lib/language_detection/version.rb
+++ b/lib/language_detection/version.rb
@@ -1,3 +1,3 @@
 module LanguageDetection
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Added `aarch64` detection to the ARM64 architecture check. This is the macro that GCC/Clang use on Linux ARM64 systems